### PR TITLE
failing test

### DIFF
--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/imported-class/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/imported-class/code.js
@@ -1,0 +1,9 @@
+import Component, { hbs } from '@glimmerx/component';
+import Button from './Button';
+
+export default class MyComponent extends Component {
+    static template = hbs`
+      <h1>Hello world!</h1>
+      <Button />
+    `
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/imported-class/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/imported-class/output.js
@@ -1,0 +1,17 @@
+import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import Component, { hbs } from '@glimmerx/component';
+import Button from './Button';
+export default class MyComponent extends Component {}
+
+_setComponentTemplate(MyComponent, {
+  id: "+PEr61nc",
+  block: "{\"symbols\":[],\"statements\":[[0,\"\\n      \"],[7,\"h1\",true],[9],[0,\"Hello world!\"],[10],[0,\"\\n      \"],[5,\"Button\",[],[[],[]],null],[0,\"\\n    \"]],\"hasEval\":false}",
+  meta: {
+    scope: () => ({
+      Component,
+      hbs,
+      Button,
+      MyComponent
+    })
+  }
+});


### PR DESCRIPTION
input:
```js
import Component, { hbs } from '@glimmerx/component';
import Button from './Button';

 export default class MyComponent extends Component {
    static template = hbs`
      <h1>Hello world!</h1>
      <Button />
    `
} 
```

output:
```js
import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
import Component, { hbs } from '@glimmerx/component';
import Button from './Button';
export default class MyComponent extends Component {}

 _setComponentTemplate(MyComponent, {
  id: "+PEr61nc",
  block: "{\"symbols\":[],\"statements\":[[0,\"\\n      \"],[7,\"h1\",true],[9],[0,\"Hello world!\"],[10],[0,\"\\n      \"],[5,\"Button\",[],[[],[]],null],[0,\"\\n    \"]],\"hasEval\":false}",
  meta: {
    scope: () => ({
      Component,
      hbs,
      Button,
      MyComponent
    })
  }
}); 
```

expected output (maybe wrong):
```js
import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
import Component, { hbs } from '@glimmerx/component';
import Button from './Button';
export default class MyComponent extends Component {}

 _setComponentTemplate(MyComponent, {
  id: "+PEr61nc",
  block: "{\"symbols\":[],\"statements\":[[0,\"\\n      \"],[7,\"h1\",true],[9],[0,\"Hello world!\"],[10],[0,\"\\n      \"],[5,\"Button\",[],[[],[]],null],[0,\"\\n    \"]],\"hasEval\":false}",
  meta: {
    scope: () => ({
      Button,
      MyComponent
    })
  }
}); 
```