### PR TITLE
Adds .js files to prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+packages/@glimmerx/babel-plugin-component-templates/test/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "scripts": {
     "build": "scripts/build.js",
-    "format": "prettier --write 'packages/**/*.ts'",
+    "format": "prettier --write 'packages/**/*.{js,ts}'",
     "start": "webpack-dev-server",
     "test": "testem ci",
     "test:watch": "testem"

--- a/packages/@glimmerx/babel-plugin-component-templates/index.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/index.js
@@ -3,17 +3,16 @@ const { addNamed } = require('@babel/helper-module-imports');
 
 module.exports = function(babel, options) {
   const { types: t, parse } = babel;
-  const {
-    importPath = '@glimmerx/core',
-    importName = 'setComponentTemplate'
-  } = options || {};
+  const { importPath = '@glimmerx/core', importName = 'setComponentTemplate' } = options || {};
 
   function maybeAddTemplateSetterImport(state, programPath) {
     if (state.templateSetter) {
       return state.templateSetter;
     }
 
-    return state.templateSetter = addNamed(programPath, importName, importPath, { importedType: 'es6' });
+    return (state.templateSetter = addNamed(programPath, importName, importPath, {
+      importedType: 'es6',
+    }));
   }
 
   return {
@@ -42,7 +41,7 @@ module.exports = function(babel, options) {
         bindings.forEach(binding => {
           binding.reference(programPath);
         });
-      }
+      },
     },
   };
 
@@ -51,9 +50,7 @@ module.exports = function(babel, options) {
     const template = buildTemplate(path);
 
     if (klass.isClassExpression()) {
-      klass.replaceWith(
-        t.callExpression(setter, [klass.node, template])
-      );
+      klass.replaceWith(t.callExpression(setter, [klass.node, template]));
     } else {
       const klassId = klass.node.id;
 
@@ -106,4 +103,4 @@ module.exports = function(babel, options) {
     }
     return path.node.value.quasis[0].value.raw;
   }
-}
+};

--- a/packages/@glimmerx/babel-plugin-component-templates/test/index.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/index.js
@@ -4,5 +4,5 @@ import path from 'path';
 
 pluginTester({
   plugin,
-  fixtures: path.join(__dirname, 'fixtures')
+  fixtures: path.join(__dirname, 'fixtures'),
 });


### PR DESCRIPTION
Adds `.js` files to the `yarn format` command. Also adds a `.prettierignore` file that excludes the Babel plugin's test fixtures from being reformatted.