### PR TITLE
Expose options.precompile for precompileOptions

### DIFF
--- a/packages/@glimmerx/babel-plugin-component-templates/index.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/index.js
@@ -78,7 +78,11 @@ function getTemplateTokens(html) {
 
 module.exports = function(babel, options) {
   const { types: t, parse } = babel;
-  const { importPath = '@glimmerx/core', importName = 'setComponentTemplate' } = options || {};
+  const {
+    importPath = '@glimmerx/core',
+    importName = 'setComponentTemplate',
+    precompile: precompileOptions,
+  } = options || {};
 
   function maybeAddTemplateSetterImport(state, programPath) {
     if (state.templateSetter) {
@@ -136,7 +140,7 @@ module.exports = function(babel, options) {
   function buildTemplate(path) {
     const templateSource = getTemplateString(path);
     const templateScopeTokens = getTemplateTokens(templateSource);
-    const compiled = precompile(templateSource);
+    const compiled = precompile(templateSource, precompileOptions);
     const ast = parse(`(${compiled})`);
 
     t.traverseFast(ast, node => {

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/code.js
@@ -1,0 +1,3 @@
+class MyComponent extends Component {
+  static template = hbs`{{bad}}<h1>Hello world</h1>`;
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/options.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/options.js
@@ -1,0 +1,27 @@
+// babel-plugin-test only supports options as an options.json file,
+// so we have to manually pass this through to our fixture.
+
+const precompileOptions = {
+  meta: {},
+  plugins: {
+    ast: [
+      () => {
+        return {
+          name: 'remove-bad-helper',
+          visitor: {
+            MustacheStatement(node) {
+              if (node.path.original == 'bad') {
+                return null;
+              }
+            },
+          },
+        };
+      },
+    ],
+  },
+  mode: 'precompile',
+};
+
+export default {
+  precompile: precompileOptions,
+};

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/output.js
@@ -1,0 +1,12 @@
+
+import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+
+class MyComponent extends Component {}
+
+_setComponentTemplate(MyComponent, {
+  id: "pX6MO7j4",
+  block: "{\"symbols\":[],\"statements\":[[7,\"h1\",true],[9],[0,\"Hello world\"],[10]],\"hasEval\":false}",
+  meta: {
+    scope: () => ({})
+  }
+})

--- a/packages/@glimmerx/babel-plugin-component-templates/test/index.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/index.js
@@ -1,8 +1,17 @@
 import plugin from '..';
 import pluginTester from 'babel-plugin-tester';
 import path from 'path';
+import astTransformTestPluginOptions from './fixtures-options/precompile/ast-transform/options';
 
 pluginTester({
   plugin,
   fixtures: path.join(__dirname, 'fixtures'),
+  tests: [
+    {
+      title: 'options.precompile : ast transfrom',
+      fixture: path.join(__dirname, 'fixtures-options/precompile/ast-transform/code.js'),
+      outputFixture: path.join(__dirname, 'fixtures-options/precompile/ast-transform/output.js'),
+      pluginOptions: astTransformTestPluginOptions,
+    },
+  ],
 });


### PR DESCRIPTION
**Added**
- An option to the plugin `precompile`, to pass through precompileOptions to the precompile method.
- Added a test to see if a AST transform will work.