### PR TITLE
Adding modifier package and with the on modifier and action decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ export default class extends Component {
 }
 ```
 
-### `@glimmerx/services`
+### `@glimmerx/service`
 
 #### `service`
 `import { service } from '@glimmerx/service';`
@@ -155,6 +155,48 @@ Decorator to inject services into a component.
       @service locale;
       get currentLocale() {
         return this.locale.currentLocale;
+      }
+  }
+```
+
+### `@glimmerx/modifier`
+
+#### `on`
+`import { on } from '@glimmerx/modifier'`
+
+On modifier that allows components to add listeners for an dom event on an element
+
+```js
+  import Component, { hbs } from '@glimmerx/component';
+  import { on } from '@glimmerx/modifier';
+  export default class extends Component {
+      static template = hbs`
+        <button {{on "click" this.buttonClicked}}>Click Me!</button>
+      `
+
+      buttonClicked() {
+        console.log('The Button is clicked');
+      }
+  }
+```
+
+#### `action`
+`import { action } from '@glimmerx/modifier'`
+
+A decorator to bind a function to a component instance. This is required to set the `this` scope for a passed in function to any modifier.
+
+```js
+  import Component, { hbs, tracked } from '@glimmerx/component';
+  import { on, action } from '@glimmerx/modifier';
+  export default class extends Component {
+      static template = hbs`
+        <button {{on "click" this.incrementCounter}}>Counter: {{this.count}}</button>
+      `
+      @tracked count = 1;
+
+      @action
+      incrementCounter() {
+        this.count++;
       }
   }
 ```

--- a/packages/@glimmerx/core/src/renderComponent/CompileTimeResolver.ts
+++ b/packages/@glimmerx/core/src/renderComponent/CompileTimeResolver.ts
@@ -4,7 +4,7 @@ import { ResolverDelegate, templateFactory } from '@glimmer/opcode-compiler';
 
 import RuntimeResolverDelegate from './RuntimeResolver';
 import { TemplateMeta, Constructor } from '../interfaces';
-import { definitionForComponent, definitionForHelper } from './definitions';
+import { definitionForComponent, definitionForHelper, Modifier, handleForModifier } from './definitions';
 
 export default class CompileTimeResolver implements ResolverDelegate {
   constructor(private runtimeResolver: RuntimeResolverDelegate) {}
@@ -20,8 +20,16 @@ export default class CompileTimeResolver implements ResolverDelegate {
     return handle;
   }
 
-  lookupModifier(_name: string, _referrer: unknown): Option<number> {
-    throw new Error('Method not implemented.');
+  lookupModifier(name: string, referrer: TemplateMeta): Option<number> {
+    const scope = referrer.scope();
+    const modifier = (scope[name] as any) as Modifier;
+    if (!modifier) {
+      throw new Error(`Cannot find modifier ${name} in scope`);
+    }
+
+    const handle = handleForModifier(modifier);
+    this.runtimeResolver.registry[handle] = modifier;
+    return handle;
   }
 
   lookupComponent(name: string, referrer: TemplateMeta): Option<CompileTimeComponent> {

--- a/packages/@glimmerx/core/src/renderComponent/definitions.ts
+++ b/packages/@glimmerx/core/src/renderComponent/definitions.ts
@@ -1,6 +1,6 @@
 import { CAPABILITIES } from './capabilities';
 import Component from '@glimmerx/component';
-import { ComponentDefinition, Helper as GlimmerHelper } from '@glimmer/interfaces';
+import { ComponentDefinition, Helper as GlimmerHelper, ModifierManager } from '@glimmer/interfaces';
 
 import { getComponentManager } from '../setComponentManager';
 import { getComponentTemplate } from '../setComponentTemplate';
@@ -13,8 +13,14 @@ interface HelperDefinition {
   };
 }
 
+export interface Modifier {
+  state: any;
+  manager: ModifierManager;
+}
+
 const COMPONENT_DEFINITIONS = new WeakMap<Constructor<Component>, ComponentDefinition>();
 const HELPER_DEFINITIONS = new WeakMap<GlimmerHelper, HelperDefinition>();
+const MODIFIER_HANDLES = new WeakMap<Modifier, number>();
 
 export function definitionForComponent(
   ComponentClass: Constructor<Component>
@@ -27,6 +33,17 @@ export function definitionForHelper(Helper: GlimmerHelper): HelperDefinition {
 }
 
 let HANDLE = 0;
+
+export function handleForModifier(modifier: Modifier) {
+  let handle = MODIFIER_HANDLES.get(modifier);
+
+  if (!handle) {
+    handle = HANDLE++;
+    MODIFIER_HANDLES.set(modifier, handle);
+  }
+
+  return handle;
+}
 
 function createComponentDefinition(ComponentClass: Constructor<Component>): ComponentDefinition {
   const manager = getComponentManager(ComponentClass)!;

--- a/packages/@glimmerx/core/src/renderComponent/index.ts
+++ b/packages/@glimmerx/core/src/renderComponent/index.ts
@@ -21,7 +21,10 @@ import { RootReference } from '@glimmer/reference';
 export interface RenderComponentOptions {
   element: Element;
   services?: Dict<unknown>;
+  reRendered?: () => void;
 }
+
+const reRenderNotifiers: Array<() => void> = [];
 
 async function renderComponent(
   ComponentClass: Constructor<Component>,
@@ -41,6 +44,10 @@ async function renderComponent(
   const iterator = getTemplateIterator(ComponentClass, element, services);
   const result = iterator.sync();
   results.push(result);
+
+  if (options.reRendered) {
+    reRenderNotifiers.push(options.reRendered);
+  }
 }
 
 export default renderComponent;
@@ -59,6 +66,8 @@ function scheduleRevalidation() {
   setTimeout(() => {
     scheduled = false;
     revalidate();
+
+    reRenderNotifiers.forEach((notifier) => notifier());
   }, 0);
 }
 

--- a/packages/@glimmerx/core/tests/index.ts
+++ b/packages/@glimmerx/core/tests/index.ts
@@ -1,4 +1,5 @@
 import './component-manager-tests';
+import './modifier-tests';
 import renderTests from './render-tests';
 import { renderComponent, RenderComponentOptions } from '..';
 import { Constructor } from '../src/interfaces';

--- a/packages/@glimmerx/core/tests/modifier-tests.ts
+++ b/packages/@glimmerx/core/tests/modifier-tests.ts
@@ -1,0 +1,44 @@
+const { module, test } = QUnit;
+
+import { on, action } from '@glimmerx/modifier';
+import Component, { tracked } from '@glimmerx/component';
+import { renderComponent, setComponentTemplate } from '..';
+import { compileTemplate } from './utils';
+
+module('Modifier Tests', () => {
+  test('Supports the on modifier', assert => {
+    const done = assert.async();
+    class MyComponent extends Component {
+      @tracked count = 0;
+
+      @action
+      incrementCounter() {
+        this.count++;
+      }
+    }
+
+    setComponentTemplate(
+      MyComponent,
+      compileTemplate(
+        `<button {{on "click" this.incrementCounter}}>Count: {{this.count}}</button>`,
+        () => ({on})
+      )
+    );
+
+    const element = document.getElementById('qunit-fixture')!;
+    const onReRender = () => {
+      assert.strictEqual(element.innerHTML, `<button>Count: 1</button>`, 'the component was rerendered');
+      done();
+    };
+
+    renderComponent(MyComponent, {
+      element,
+      reRendered: onReRender
+    });
+
+    assert.strictEqual(element.innerHTML, `<button>Count: 0</button>`, 'the component was rendered');
+
+    const button = element.querySelector('button')!;
+    button.click();
+  });
+});

--- a/packages/@glimmerx/core/tests/render-tests.ts
+++ b/packages/@glimmerx/core/tests/render-tests.ts
@@ -1,9 +1,10 @@
-import Component from '@glimmerx/component';
+import Component, { tracked } from '@glimmerx/component';
 
 import { compileTemplate } from './utils';
 import { setComponentTemplate } from '../src/setComponentTemplate';
 import { helper } from '@glimmerx/helper';
 import { service } from '@glimmerx/service';
+import { on, action } from '@glimmerx/modifier';
 import { Constructor } from '../src/interfaces';
 
 const { module, test } = QUnit;
@@ -137,6 +138,28 @@ export default function renderTests(moduleName: string, render: (component: Cons
       html = await render(MyComponent);
       assert.strictEqual(html, '<h1>Bump</h1>', 'the component was rendered again');
       assert.ok(true, 'rendered');
+    });
+
+    test('a component can use modifiers', async assert => {
+      class MyComponent extends Component {
+        @tracked count = 0;
+
+        @action
+        incrementCounter() {
+          this.count++;
+        }
+      }
+
+      setComponentTemplate(
+        MyComponent,
+        compileTemplate(
+          `<button {{on "click" this.incrementCounter}}>Count: {{this.count}}</button>`,
+          () => ({on})
+        )
+      );
+
+      let html = await render(MyComponent);
+      assert.strictEqual(html, `<button>Count: 0</button>`, 'the component was rendered');
     });
   });
 }

--- a/packages/@glimmerx/modifier/index.ts
+++ b/packages/@glimmerx/modifier/index.ts
@@ -1,0 +1,2 @@
+export { on } from './src/on';
+export { action } from './src/action';

--- a/packages/@glimmerx/modifier/package.json
+++ b/packages/@glimmerx/modifier/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@glimmerx/modifier",
+  "version": "0.0.4",
+  "description": "Modifier Functionality",
+  "main": "dist/index.js",
+  "repository": "https://github.com/tomdale/glimmer-lite",
+  "author": "Tom Dale <tom@tomdale.net>",
+  "license": "MIT",
+  "private": false,
+  "scripts": {
+    "build": "webpack"
+  },
+  "dependencies": {
+    "@glimmer/interfaces": "^0.41.0",
+    "@simple-dom/interface": "^1.4.0"
+  }
+}

--- a/packages/@glimmerx/modifier/src/action.ts
+++ b/packages/@glimmerx/modifier/src/action.ts
@@ -1,0 +1,29 @@
+const BINDINGS_MAP = new WeakMap();
+
+export function action(target: any, key: any): any;
+export function action(target: any, key: any, descriptor: PropertyDescriptor): PropertyDescriptor;
+export function action(...args: any[]): any {
+  let [,,desc] = args;
+
+  const actionFn = desc.value;
+
+  return {
+    enumerable: desc.enumerable,
+    configurable: desc.configurable,
+    get() {
+      let bindings = BINDINGS_MAP.get(this);
+      if (bindings === undefined) {
+        bindings = new Map();
+        BINDINGS_MAP.set(this, bindings);
+      }
+
+      let fn = bindings.get(actionFn);
+      if (fn === undefined) {
+        fn = actionFn.bind(this);
+        bindings.set(actionFn, fn);
+      }
+
+      return fn;
+    }
+  };
+}

--- a/packages/@glimmerx/modifier/src/on.ts
+++ b/packages/@glimmerx/modifier/src/on.ts
@@ -1,0 +1,117 @@
+import { ModifierManager, VMArguments, Destroyable, CapturedArguments } from '@glimmer/interfaces';
+import { SimpleElement } from '@simple-dom/interface';
+import { TagWrapper, RevisionTag, Tag, CONSTANT_TAG } from '@glimmer/reference';
+
+class OnModifierState {
+  public element: Element;
+  private args: CapturedArguments;
+  public tag: Tag;
+
+  public eventName: string;
+  public callback: EventListener;
+
+  public shouldUpdate = true;
+
+
+  constructor(element: Element, args: CapturedArguments) {
+    this.element = element;
+    this.args = args;
+    this.tag = args.tag;
+  }
+
+  updateFromArgs() {
+    let { args } = this;
+
+    let eventName = args.positional.at(0).value() as string;
+
+    if (eventName !== this.eventName) {
+      this.eventName = eventName;
+      this.shouldUpdate = true;
+    }
+
+    let callback = args.positional.at(1).value() as EventListener;
+
+    if (callback !== this.callback) {
+      this.callback = callback;
+      this.shouldUpdate = true;
+    }
+  }
+
+  destroy() {
+    this.element.removeEventListener(this.eventName, this.callback);
+  }
+}
+
+class OnModifierManager implements ModifierManager<OnModifierState | null, null> {
+  public isInteractive: boolean;
+
+  constructor() {
+    this.isInteractive = typeof document !== 'undefined';
+  }
+
+  create(
+    element: SimpleElement,
+    state: null,
+    args: VMArguments
+  ): OnModifierState | null {
+    if (!this.isInteractive) {
+      return null;
+    }
+
+    const capturedArgs = args.capture();
+    return new OnModifierState(<Element>element, capturedArgs);
+  }
+
+  getTag(state: OnModifierState | null): TagWrapper<RevisionTag | null> {
+    if (state === null) {
+      return CONSTANT_TAG;
+    } else {
+      return state.tag;
+    }
+  }
+
+  install(state: OnModifierState | null): void {
+    if (state === null) {
+      return;
+    }
+
+    state.updateFromArgs();
+
+    const { element, eventName, callback } = state;
+    element.addEventListener(eventName, callback);
+
+    state.shouldUpdate = false;
+  }
+
+  update(state: OnModifierState | null): void {
+    if (state === null) {
+      return;
+    }
+
+    // stash prior state for el.removeEventListener
+    const { element, eventName, callback } = state;
+
+    state.updateFromArgs();
+
+    if (!state.shouldUpdate) {
+      return;
+    }
+
+    // use prior state values for removal
+    element.removeEventListener(eventName, callback);
+
+    // read updated values from the state object
+    state.element.addEventListener(state.eventName, state.callback);
+
+    state.shouldUpdate = false;
+  }
+
+  getDestructor(state: OnModifierState | null) {
+    return state;
+  }
+}
+
+export const on = {
+  state: null,
+  manager: new OnModifierManager()
+};

--- a/packages/@glimmerx/service/src/decorator.ts
+++ b/packages/@glimmerx/service/src/decorator.ts
@@ -3,8 +3,7 @@ import { getService } from './setServices';
 export function service(target: any, key: any): any;
 export function service(target: any, key: any, descriptor: PropertyDescriptor): PropertyDescriptor;
 export function service(...args: any[]): any {
-  let [, key] = args;
-
+  let [,key] = args;
   return {
     enumerable: true,
     configurable: false,

--- a/packages/example-app/src/MyComponent.ts
+++ b/packages/example-app/src/MyComponent.ts
@@ -2,6 +2,7 @@ import Component, { tracked, hbs } from '@glimmerx/component';
 import { helper } from '@glimmerx/helper';
 import OtherComponent from './OtherComponent';
 import { service } from '@glimmerx/service';
+import { on, action } from '@glimmerx/modifier';
 import LocaleService from './services/LocaleService';
 
 const myHelper = helper(function([name], { greeting }) {
@@ -17,8 +18,7 @@ const isCJK = helper(function(args, hash, { services }) {
 
 class MyComponent extends Component {
   static template = hbs`
-    <h1>Hello {{this.message}}</h1>
-    <OtherComponent @count={{this.count}} />
+    <h1>Hello {{this.message}}</h1> <br/>
     {{myHelper "foo" greeting="Hello"}}
     <p>Current locale: {{this.currentLocale}}</p>
     {{#if (isCJK)}}
@@ -26,21 +26,22 @@ class MyComponent extends Component {
     {{else}}
       <p>Component is not in a CJK locale</p>
     {{/if}}
+
+    <OtherComponent @count={{this.count}} /> <br/>
+    <button {{on "click" this.increment}}>Increment</button>
   `;
 
   message = 'hello world';
   @tracked count = 55;
   @service locale: LocaleService;
 
-  constructor(owner: unknown, args: object) {
-    super(owner, args);
-    setInterval(() => {
-      this.count++;
-    }, 16);
-  }
-
   get currentLocale() {
     return this.locale.currentLocale;
+  }
+
+  @action
+  increment() {
+    this.count++;
   }
 }
 

--- a/packages/example-app/src/OtherComponent.ts
+++ b/packages/example-app/src/OtherComponent.ts
@@ -1,5 +1,5 @@
 import Component, { hbs } from '@glimmerx/component';
 
 export default class OtherComponent extends Component {
-  static template = hbs`<b>hi {{@count}}</b>`;
+  static template = hbs`<b>Counter Val: {{@count}}</b>`;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1275,6 +1275,13 @@
     "@glimmer/runtime" "^0.41.0"
     "@simple-dom/interface" "^1.4.0"
 
+"@glimmerx/service@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@glimmerx/service/-/service-0.0.3.tgz#4950d87193de2b39bfe43f641713e78647a463fe"
+  integrity sha512-BnJ1vzDW1quHuM/Jf8pVfBG9Yla+R2+li+P6w4xJ/Bvrf9nMsqWksw3x0d8xCD1J7v+UKyxL6F1sgvZTW6/0KQ==
+  dependencies:
+    "@glimmer/interfaces" "^0.41.0"
+
 "@lerna/add@3.15.0":
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.15.0.tgz#10be562f43cde59b60f299083d54ac39520ec60a"


### PR DESCRIPTION
### Background
Currently glimmerx supports client side rendering of components. However it does support anyway to listen to DOM events to update components. Glimmer-VM provides an abstraction for this via modifiers. 

This PR implements basic support for modifiers as well as adds supports for the [on modifier](https://github.com/emberjs/rfcs/blob/master/text/0471-on-modifier.md). The on modifier will allow a component to hook into any DOM event and invoke a callback when the even occurs. The component can then update any state it needs to in this callback.

### Implementation Details

- @glimmerx/modifier
This package serves as the home for any native modifiers that the framework will provide. In this PR we are adding the on modifier and the action decorator

- On modifier
The on modifier allows a glimmer component to listen to any dom event on an element. The modifier currently supports only an event name and a callback function for when the event is tricket

- Action decorator
This decorator binds functions to the instance they are being called on. This makes sure the `this` context is set correctly on the method. The decorator also caches the bound functions so that they are not rebound on every lookup.

- Modifier Handles
Modifier handles are assigned in the definitions.ts map. The mappings are maintained via WeakMap from the ModifierDefinition to a handle.

I also updated the example app to use the new modifier and changed the app to have a button to increment the counter instead of being in a setTimeout call. 