### PR TITLE
Export a didRender function from core

### DIFF
--- a/packages/@glimmerx/core/index.ts
+++ b/packages/@glimmerx/core/index.ts
@@ -1,4 +1,4 @@
-export { default as renderComponent, RenderComponentOptions } from './src/renderComponent';
+export { default as renderComponent, RenderComponentOptions, didRender } from './src/renderComponent';
 
 export { Constructor } from './src/interfaces';
 

--- a/packages/@glimmerx/core/tests/modifier-tests.ts
+++ b/packages/@glimmerx/core/tests/modifier-tests.ts
@@ -2,12 +2,11 @@ const { module, test } = QUnit;
 
 import { on, action } from '@glimmerx/modifier';
 import Component, { tracked } from '@glimmerx/component';
-import { renderComponent, setComponentTemplate } from '..';
+import { renderComponent, setComponentTemplate, didRender } from '..';
 import { compileTemplate } from './utils';
 
 module('Modifier Tests', () => {
-  test('Supports the on modifier', assert => {
-    const done = assert.async();
+  test('Supports the on modifier', async assert => {
     class MyComponent extends Component {
       @tracked count = 0;
 
@@ -26,19 +25,14 @@ module('Modifier Tests', () => {
     );
 
     const element = document.getElementById('qunit-fixture')!;
-    const onReRender = () => {
-      assert.strictEqual(element.innerHTML, `<button>Count: 1</button>`, 'the component was rerendered');
-      done();
-    };
 
-    renderComponent(MyComponent, {
-      element,
-      reRendered: onReRender
-    });
-
+    await renderComponent(MyComponent, element);
     assert.strictEqual(element.innerHTML, `<button>Count: 0</button>`, 'the component was rendered');
 
     const button = element.querySelector('button')!;
     button.click();
+
+    await didRender();
+    assert.strictEqual(element.innerHTML, `<button>Count: 1</button>`, 'the component was rerendered');
   });
 });


### PR DESCRIPTION
**Background**
Currently there is a callback based mechanism to be notified about re renders after the intial render. These notifications are especially useful in tests that expect templates to rerender after some state change for e.g. a button click. The current callback based mechanism works fine but requires using the done callback pattern in qunit. It is more natural for a developer to use async/await for something like this rather than remembering to call a done callback.

**Solution**
In this PR we expose a new function from @glimmerx/core, `didRender`. This function returns a promise that when resolved guarantees that the render's in the pipeline have finished. This will allow us to switch over to use async/await in the tests.