### PR TITLE
Allow for data in options for renderComponent API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,24 @@ import MyComponent from './MyComponent';
 renderComponent(MyComponent, document.getElementById('app'));
 ```
 
+Renders a component with data passed as arguments to the component. First arugment is the Glimmer Component, the second argument is an object of render options, with the target DOM element and the data to pass to the component to render.
+
+```js
+import { renderComponent } from '@glimmerx/core';
+import Component, { hbs } from '@glimmerx/component';
+
+class OtherComponent extends Component {
+  static template = hbs`<h1>{{@say}}</h1>`;
+}
+
+renderComponent(MyComponent, {
+  element: document.getElementById('app'),
+  data: {
+    say: "Hello World"
+  }
+});
+```
+
 Service implementations for injection in components/helpers can be provided when calling renderComponent.
 
 ```js

--- a/packages/@glimmerx/core/index.ts
+++ b/packages/@glimmerx/core/index.ts
@@ -1,4 +1,4 @@
-export { default as renderComponent, RenderComponentOptions, didRender } from './src/renderComponent';
+export { default as renderComponent, RenderComponentOptions, didRender, dictToReference } from './src/renderComponent';
 
 export { Constructor } from './src/interfaces';
 

--- a/packages/@glimmerx/core/tests/render-tests.ts
+++ b/packages/@glimmerx/core/tests/render-tests.ts
@@ -77,6 +77,19 @@ export default function renderTests(moduleName: string, render: (component: Cons
       assert.strictEqual(html, '<h1>helper Hello foo</h1>', 'the template was rendered');
     });
 
+    test('a component can render with args', async assert => {
+      class MyComponent extends Component {}
+
+      setComponentTemplate(MyComponent, compileTemplate('<h1>{{@say}}</h1>'));
+
+      const html = await render(MyComponent, {
+        data: {
+          say: 'Hello Dolly!',
+        }
+      });
+      assert.strictEqual(html, '<h1>Hello Dolly!</h1>', 'the component is rendered with passed in data as args');
+    });
+
     test('a component can inject services', async assert => {
       class LocaleService {
         get currentLocale() {

--- a/packages/@glimmerx/ssr/src/render.ts
+++ b/packages/@glimmerx/ssr/src/render.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmerx/component';
-import { RuntimeResolver, CompileTimeResolver, definitionForComponent, Constructor } from '@glimmerx/core';
+import { RuntimeResolver, CompileTimeResolver, definitionForComponent, Constructor, dictToReference } from '@glimmerx/core';
 import { Dict } from '@glimmer/interfaces';
 import { JitContext } from '@glimmer/opcode-compiler';
 import Environment from './environment';
@@ -19,17 +19,6 @@ export interface RenderOptions {
 };
 
 const serializer = new HTMLSerializer(voidMap);
-
-function dictToReference(dict?: Dict<unknown>): Dict<PathReference> {
-  if (!dict) {
-    return {};
-  }
-
-  return Object.keys(dict).reduce((acc, key) => {
-    acc[key] = new RootReference(dict[key]);
-    return acc;
-  }, {} as Dict<PathReference>);
-}
 
 export function renderToString(ComponentClass: Constructor<Component>, options?: RenderOptions): Promise<string> {
   return new Promise<string>((resolve, reject) => {


### PR DESCRIPTION
- Looks for `data` attribute in options argument.
- Mirrors `SSR` API
- `@glimmer/core` exports `dictToReference` utility method, made available to share with `@glimmerx/ssr`.