### PR TITLE
RenderOptions data property renamed to args

### DIFF
--- a/packages/@glimmerx/core/src/renderComponent/index.ts
+++ b/packages/@glimmerx/core/src/renderComponent/index.ts
@@ -20,7 +20,7 @@ import { RootReference, PathReference } from '@glimmer/reference';
 
 export interface RenderComponentOptions {
   element: Element;
-  data?: Dict<unknown>;
+  args?: Dict<unknown>;
   services?: Dict<unknown>;
 }
 
@@ -53,8 +53,8 @@ async function renderComponent(
 ): Promise<void> {
   const options: RenderComponentOptions =
     optionsOrElement instanceof HTMLElement ? { element: optionsOrElement } : optionsOrElement;
-  const { element, services, data } = options;
-  const iterator = getTemplateIterator(ComponentClass, element, data, services);
+  const { element, services, args } = options;
+  const iterator = getTemplateIterator(ComponentClass, element, args, services);
   const result = iterator.sync();
   results.push(result);
 }

--- a/packages/@glimmerx/core/tests/render-tests.ts
+++ b/packages/@glimmerx/core/tests/render-tests.ts
@@ -82,12 +82,14 @@ export default function renderTests(moduleName: string, render: (component: Cons
 
       setComponentTemplate(MyComponent, compileTemplate('<h1>{{@say}}</h1>'));
 
-      const html = await render(MyComponent, {
-        data: {
+      const renderOptions = {
+        args: {
           say: 'Hello Dolly!',
         }
-      });
-      assert.strictEqual(html, '<h1>Hello Dolly!</h1>', 'the component is rendered with passed in data as args');
+      };
+
+      const html = await render(MyComponent, renderOptions);
+      assert.strictEqual(html, '<h1>Hello Dolly!</h1>', 'the component is rendered with passed in args');
     });
 
     test('a component can inject services', async assert => {

--- a/packages/@glimmerx/ssr/src/render.ts
+++ b/packages/@glimmerx/ssr/src/render.ts
@@ -5,7 +5,7 @@ import { JitContext } from '@glimmer/opcode-compiler';
 import Environment from './environment';
 import { CustomJitRuntime, DefaultDynamicScope, renderJitComponent } from '@glimmer/runtime';
 import { StringBuilder } from '@glimmer/ssr';
-import { RootReference, PathReference } from '@glimmer/reference';
+import { RootReference } from '@glimmer/reference';
 import createHTMLDocument from '@simple-dom/document';
 import { DYNAMIC_SCOPE_SERVICES_KEY } from '@glimmerx/service';
 import HTMLSerializer from '@simple-dom/serializer';
@@ -14,7 +14,7 @@ import { SimpleElement } from '@simple-dom/interface';
 import { PassThrough } from 'stream';
 
 export interface RenderOptions {
-  data?: Dict<unknown>;
+  args?: Dict<unknown>;
   serializer?: HTMLSerializer;
   services?: Dict<unknown>;
 };
@@ -36,7 +36,7 @@ export function renderToString(ComponentClass: Constructor<Component>, options?:
 
 export function renderToStream(stream: NodeJS.WritableStream, ComponentClass: Constructor<Component>, options: RenderOptions = {}) {
   const element = createHTMLDocument().body;
-  const iterator = getTemplateIterator(ComponentClass, element, options.data, options.services);
+  const iterator = getTemplateIterator(ComponentClass, element, options.args, options.services);
   iterator.sync();
 
   const serializer = options.serializer || defaultSerializer;


### PR DESCRIPTION
- Renamed property `data` to `args`  in RenderOptions
- Removed un-used PathReference in ssr package.