### PR TITLE
Changes to support compilation of template only components 

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,30 +3,8 @@
   <head>
     <title>Glimmer Demo</title>
   </head>
-  <style>
-    h2 {
-      font-size: 2.5rem;
-      font-weight: 300;
-      line-height: 1.2;
-      color: #777777;
-    }
-    section {
-      padding: 1rem;
-      margin: .25rem;
-      background-color: #f5f5f5;
-      border: 0.1rem solid #dee2e6;
-    }
-    #app, #app-hbs {
-      background: #fdfdfd;
-      padding: 1rem;
-      border: 0.1rem solid #ccc;
-    }
-  </style>
   <body>
-    <section>
-      <h2>Static Class Property Component</h2>
-      <div id="app"></div>
-    </section>
+    <div id="app"></div>
     <script src="./app.bundle.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,30 @@
   <head>
     <title>Glimmer Demo</title>
   </head>
+  <style>
+    h2 {
+      font-size: 2.5rem;
+      font-weight: 300;
+      line-height: 1.2;
+      color: #777777;
+    }
+    section {
+      padding: 1rem;
+      margin: .25rem;
+      background-color: #f5f5f5;
+      border: 0.1rem solid #dee2e6;
+    }
+    #app, #app-hbs {
+      background: #fdfdfd;
+      padding: 1rem;
+      border: 0.1rem solid #ccc;
+    }
+  </style>
   <body>
-    <div id="app"></div>
+    <section>
+      <h2>Static Class Property Component</h2>
+      <div id="app"></div>
+    </section>
     <script src="./app.bundle.js"></script>
   </body>
 </html>

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform-hbs/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform-hbs/code.js
@@ -1,0 +1,3 @@
+import { hbs } from '@glimmerx/component';
+
+const template = hbs`{{bad}}<h1>Hello world</h1>`;

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform-hbs/options.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform-hbs/options.js
@@ -1,0 +1,27 @@
+// babel-plugin-test only supports options as an options.json file,
+// so we have to manually pass this through to our fixture.
+
+const precompileOptions = {
+  meta: {},
+  plugins: {
+    ast: [
+      () => {
+        return {
+          name: 'remove-bad-helper',
+          visitor: {
+            MustacheStatement(node) {
+              if (node.path.original == 'bad') {
+                return null;
+              }
+            },
+          },
+        };
+      },
+    ],
+  },
+  mode: 'precompile',
+};
+
+export default {
+  precompile: precompileOptions,
+};

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform-hbs/output.js
@@ -1,7 +1,8 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
-import Component, { hbs } from '@glimmerx/component';
+import _Component from "@glimmerx/component";
+import { hbs } from '@glimmerx/component';
 
-const MyComponent = _setComponentTemplate(class extends Component {}, {
+const template = _setComponentTemplate(class extends _Component {}, {
   id: "pX6MO7j4",
   block: "{\"symbols\":[],\"statements\":[[7,\"h1\",true],[9],[0,\"Hello world\"],[10]],\"hasEval\":false}",
   meta: {

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform-hbs/output.js
@@ -1,6 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
 import _Component from "@glimmerx/component";
-import { hbs } from '@glimmerx/component';
 
 const template = _setComponentTemplate(class extends _Component {}, {
   id: "pX6MO7j4",

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/code.js
@@ -1,3 +1,5 @@
+import Component, { hbs } from '@glimmerx/component';
+
 class MyComponent extends Component {
   static template = hbs`{{bad}}<h1>Hello world</h1>`;
 }

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/output.js
@@ -1,5 +1,5 @@
-
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import Component, { hbs } from '@glimmerx/component';
 
 class MyComponent extends Component {}
 

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/output.js
@@ -1,5 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
-import Component, { hbs } from '@glimmerx/component';
+import Component from '@glimmerx/component';
 
 class MyComponent extends Component {}
 

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled-hbs/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled-hbs/code.js
@@ -1,4 +1,4 @@
-import hbs from '@glimmer/inline-precompile';
+import { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import YetAnotherComponent from './YetAnotherComponent';
 

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled-hbs/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled-hbs/code.js
@@ -1,0 +1,6 @@
+import hbs from '@glimmer/inline-precompile';
+import OtherComponent from './OtherComponent';
+import YetAnotherComponent from './YetAnotherComponent';
+
+const template1 = hbs`<h1>Hello world</h1><OtherComponent/>`;
+const template2 = hbs`<YetAnotherComponent/>`;

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled-hbs/options.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled-hbs/options.js
@@ -1,0 +1,8 @@
+// babel-plugin-test only supports options as an options.json file,
+// so we have to manually pass this through to our fixture.
+
+export default {
+  precompile: {
+    disabled: true
+  },
+};

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled-hbs/output.js
@@ -1,11 +1,11 @@
+import _hbs from "glimmer-inline-precompile";
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
 import _Component from "@glimmerx/component";
-import hbs from '@glimmer/inline-precompile';
 import OtherComponent from './OtherComponent';
 import YetAnotherComponent from './YetAnotherComponent';
 
 const template1 = _setComponentTemplate(class extends _Component {}, (() => {
-  const compiledTemplate = hbs`<h1>Hello world</h1><OtherComponent/>`;
+  const compiledTemplate = _hbs`<h1>Hello world</h1><OtherComponent/>`;
 
   compiledTemplate.meta.scope = () => ({
     OtherComponent: OtherComponent
@@ -15,7 +15,7 @@ const template1 = _setComponentTemplate(class extends _Component {}, (() => {
 })());
 
 const template2 = _setComponentTemplate(class extends _Component {}, (() => {
-  const compiledTemplate = hbs`<YetAnotherComponent/>`;
+  const compiledTemplate = _hbs`<YetAnotherComponent/>`;
 
   compiledTemplate.meta.scope = () => ({
     YetAnotherComponent: YetAnotherComponent

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled-hbs/output.js
@@ -1,11 +1,10 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import _Component from "@glimmerx/component";
 import hbs from '@glimmer/inline-precompile';
 import OtherComponent from './OtherComponent';
 import YetAnotherComponent from './YetAnotherComponent';
 
-class MyComponent extends Component {}
-
-_setComponentTemplate(MyComponent, (() => {
+const template1 = _setComponentTemplate(class extends _Component {}, (() => {
   const compiledTemplate = hbs`<h1>Hello world</h1><OtherComponent/>`;
 
   compiledTemplate.meta.scope = () => ({
@@ -13,9 +12,9 @@ _setComponentTemplate(MyComponent, (() => {
   });
 
   return compiledTemplate;
-})())
+})());
 
-const MyComponentExpression = _setComponentTemplate(class extends Component {}, (() => {
+const template2 = _setComponentTemplate(class extends _Component {}, (() => {
   const compiledTemplate = hbs`<YetAnotherComponent/>`;
 
   compiledTemplate.meta.scope = () => ({

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled/code.js
@@ -1,3 +1,4 @@
+import hbs from '@glimmer/inline-precompile';
 import OtherComponent from './OtherComponent';
 import YetAnotherComponent from './YetAnotherComponent';
 

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled/code.js
@@ -1,4 +1,4 @@
-import hbs from '@glimmer/inline-precompile';
+import Component, { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import YetAnotherComponent from './YetAnotherComponent';
 

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/disabled/output.js
@@ -1,12 +1,13 @@
+import _hbs from "glimmer-inline-precompile";
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
-import hbs from '@glimmer/inline-precompile';
+import Component from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import YetAnotherComponent from './YetAnotherComponent';
 
 class MyComponent extends Component {}
 
 _setComponentTemplate(MyComponent, (() => {
-  const compiledTemplate = hbs`<h1>Hello world</h1><OtherComponent/>`;
+  const compiledTemplate = _hbs`<h1>Hello world</h1><OtherComponent/>`;
 
   compiledTemplate.meta.scope = () => ({
     OtherComponent: OtherComponent
@@ -16,7 +17,7 @@ _setComponentTemplate(MyComponent, (() => {
 })())
 
 const MyComponentExpression = _setComponentTemplate(class extends Component {}, (() => {
-  const compiledTemplate = hbs`<YetAnotherComponent/>`;
+  const compiledTemplate = _hbs`<YetAnotherComponent/>`;
 
   compiledTemplate.meta.scope = () => ({
     YetAnotherComponent: YetAnotherComponent

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-declaration/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-declaration/code.js
@@ -1,4 +1,4 @@
-
+import Component, { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 const unknownValue = null;
 const MaybeComponent = null;

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-declaration/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-declaration/output.js
@@ -1,4 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import Component, { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 const unknownValue = null;
 const MaybeComponent = null;

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-declaration/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-declaration/output.js
@@ -1,5 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
-import Component, { hbs } from '@glimmerx/component';
+import Component from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 const unknownValue = null;
 const MaybeComponent = null;

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-expression/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-expression/code.js
@@ -1,3 +1,4 @@
+import Component, { hbs } from '@glimmerx/component';
 
 const MyComponent = class extends Component {
   static template = hbs`<h1>Hello world</h1>`;

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-expression/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-expression/output.js
@@ -1,5 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
-import Component, { hbs } from '@glimmerx/component';
+import Component from '@glimmerx/component';
 
 const MyComponent = _setComponentTemplate(class extends Component {}, {
   id: "pX6MO7j4",

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/custom-imports/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/custom-imports/code.js
@@ -1,3 +1,4 @@
+import Component, { hbs } from '@glimmerx/component';
 
 class Class1Declaration extends Component {
   static template = hbs`<h1>Hello world</h1>`;

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/custom-imports/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/custom-imports/output.js
@@ -1,5 +1,5 @@
 import { dangerouslySetComponentTemplate as _dangerouslySetComponentTemplate } from "@glimmerx/other-package";
-import Component, { hbs } from '@glimmerx/component';
+import Component from '@glimmerx/component';
 
 class Class1Declaration extends Component {}
 

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/custom-imports/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/custom-imports/output.js
@@ -1,4 +1,5 @@
 import { dangerouslySetComponentTemplate as _dangerouslySetComponentTemplate } from "@glimmerx/other-package";
+import Component, { hbs } from '@glimmerx/component';
 
 class Class1Declaration extends Component {}
 

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes/code.js
@@ -1,3 +1,4 @@
+import Component, { hbs } from '@glimmerx/component';
 
 class Class1Declaration extends Component {
   static template = hbs`<h1>Hello world</h1>`;

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes/output.js
@@ -1,4 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import Component, { hbs } from '@glimmerx/component';
 
 class Class1Declaration extends Component {}
 

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes/output.js
@@ -1,5 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
-import Component, { hbs } from '@glimmerx/component';
+import Component from '@glimmerx/component';
 
 class Class1Declaration extends Component {}
 

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiscope-tokens/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiscope-tokens/code.js
@@ -1,4 +1,4 @@
-
+import Component, { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import PhantomComponent from './PhantomComponent';
 import SecondPhantomComponent from './SecondPhantomComponent'

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiscope-tokens/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiscope-tokens/output.js
@@ -1,5 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
-import Component, { hbs } from '@glimmerx/component';
+import Component from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import PhantomComponent from './PhantomComponent';
 import SecondPhantomComponent from './SecondPhantomComponent';

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiscope-tokens/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiscope-tokens/output.js
@@ -1,4 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import Component, { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import PhantomComponent from './PhantomComponent';
 import SecondPhantomComponent from './SecondPhantomComponent';

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/nested-classes/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/nested-classes/code.js
@@ -1,4 +1,4 @@
-
+import Component, { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 
 class MyComponent extends Component {

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/nested-classes/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/nested-classes/output.js
@@ -1,4 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import Component, { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 
 class MyComponent extends Component {

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/nested-classes/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/nested-classes/output.js
@@ -1,5 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
-import Component, { hbs } from '@glimmerx/component';
+import Component from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 
 class MyComponent extends Component {

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/phantom-scope/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/phantom-scope/code.js
@@ -1,4 +1,4 @@
-
+import Component, { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import PhantomComponent from './PhantomComponent';
 

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/phantom-scope/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/phantom-scope/output.js
@@ -1,5 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
-import Component, { hbs } from '@glimmerx/component';
+import Component from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import PhantomComponent from './PhantomComponent';
 

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/phantom-scope/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/phantom-scope/output.js
@@ -1,4 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import Component, { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import PhantomComponent from './PhantomComponent';
 

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens-hbs/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens-hbs/code.js
@@ -1,0 +1,17 @@
+import { hbs } from '@glimmerx/component';
+import OtherComponent from './OtherComponent';
+import PhantomComponent from './PhantomComponent';
+import SecondPhantomComponent from './SecondPhantomComponent'
+
+
+const hbsOnlyTemplate = hbs`
+<h1>Hello world
+    {{#OtherComponent as  |SecondPhantomComponent|}}
+        <SecondPhantomComponent />
+        {{SecondPhantomComponent}}
+    {{/OtherComponent}}
+    <OtherComponent as |PhantomComponent|>
+        <PhantomComponent />
+        {{PhantomComponent}}
+    </OtherComponent>
+</h1>`;

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens-hbs/output.js
@@ -1,0 +1,16 @@
+import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import _Component from "@glimmerx/component";
+import { hbs } from '@glimmerx/component';
+import OtherComponent from './OtherComponent';
+import PhantomComponent from './PhantomComponent';
+import SecondPhantomComponent from './SecondPhantomComponent';
+
+const hbsOnlyTemplate = _setComponentTemplate(class extends _Component {}, {
+  id: "tX2UUCNd",
+  block: "{\"symbols\":[\"PhantomComponent\",\"SecondPhantomComponent\"],\"statements\":[[0,\"\\n\"],[7,\"h1\",true],[9],[0,\"Hello world\\n\"],[4,\"OtherComponent\",null,null,[[\"default\"],[{\"statements\":[[0,\"        \"],[6,[24,2,[]],[],[[],[]],null],[0,\"\\n        \"],[1,[24,2,[]],false],[0,\"\\n\"]],\"parameters\":[2]}]]],[0,\"    \"],[5,\"OtherComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[0,\"\\n        \"],[6,[24,1,[]],[],[[],[]],null],[0,\"\\n        \"],[1,[24,1,[]],false],[0,\"\\n    \"]],\"parameters\":[1]}]]],[0,\"\\n\"],[10]],\"hasEval\":false}",
+  meta: {
+    scope: () => ({
+      OtherComponent: OtherComponent
+    })
+  }
+});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens-hbs/output.js
@@ -1,6 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
 import _Component from "@glimmerx/component";
-import { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import PhantomComponent from './PhantomComponent';
 import SecondPhantomComponent from './SecondPhantomComponent';

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens/code.js
@@ -1,4 +1,4 @@
-
+import Component, { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import PhantomComponent from './PhantomComponent';
 import SecondPhantomComponent from './SecondPhantomComponent'

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens/output.js
@@ -1,5 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
-import Component, { hbs } from '@glimmerx/component';
+import Component from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import PhantomComponent from './PhantomComponent';
 import SecondPhantomComponent from './SecondPhantomComponent';

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens/output.js
@@ -1,4 +1,5 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import Component, { hbs } from '@glimmerx/component';
 import OtherComponent from './OtherComponent';
 import PhantomComponent from './PhantomComponent';
 import SecondPhantomComponent from './SecondPhantomComponent';

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs-with-component-import/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs-with-component-import/code.js
@@ -1,0 +1,9 @@
+import { renderComponent } from '@glimmerx/core';
+import IamGlimmerComponent, { hbs } from '@glimmerx/component';
+
+renderComponent(hbs`<h1>Hello {{@name}}</h1>`, {
+  args: {
+    name: 'Abhishek'
+  },
+  element: document.body
+});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs-with-component-import/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs-with-component-import/output.js
@@ -1,6 +1,6 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
 import { renderComponent } from '@glimmerx/core';
-import IamGlimmerComponent, { hbs } from '@glimmerx/component';
+import IamGlimmerComponent from '@glimmerx/component';
 renderComponent(_setComponentTemplate(class extends IamGlimmerComponent {}, {
   id: "/eBDGAqT",
   block: "{\"symbols\":[\"@name\"],\"statements\":[[7,\"h1\",true],[9],[0,\"Hello \"],[1,[24,1,[]],false],[10]],\"hasEval\":false}",

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs-with-component-import/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs-with-component-import/output.js
@@ -1,0 +1,15 @@
+import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import { renderComponent } from '@glimmerx/core';
+import IamGlimmerComponent, { hbs } from '@glimmerx/component';
+renderComponent(_setComponentTemplate(class extends IamGlimmerComponent {}, {
+  id: "/eBDGAqT",
+  block: "{\"symbols\":[\"@name\"],\"statements\":[[7,\"h1\",true],[9],[0,\"Hello \"],[1,[24,1,[]],false],[10]],\"hasEval\":false}",
+  meta: {
+    scope: () => ({})
+  }
+}), {
+  args: {
+    name: 'Abhishek'
+  },
+  element: document.body
+});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs/code.js
@@ -1,0 +1,9 @@
+import { renderComponent } from '@glimmerx/core';
+import { hbs } from '@glimmerx/component';
+
+renderComponent(hbs`<h1>Hello {{@name}}</h1>`, {
+  args: {
+    name: 'Abhishek'
+  },
+  element: document.body
+});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs/output.js
@@ -1,0 +1,16 @@
+import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import _Component from "@glimmerx/component";
+import { renderComponent } from '@glimmerx/core';
+import { hbs } from '@glimmerx/component';
+renderComponent(_setComponentTemplate(class extends _Component {}, {
+  id: "/eBDGAqT",
+  block: "{\"symbols\":[\"@name\"],\"statements\":[[7,\"h1\",true],[9],[0,\"Hello \"],[1,[24,1,[]],false],[10]],\"hasEval\":false}",
+  meta: {
+    scope: () => ({})
+  }
+}), {
+  args: {
+    name: 'Abhishek'
+  },
+  element: document.body
+});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs/output.js
@@ -1,7 +1,6 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
 import _Component from "@glimmerx/component";
 import { renderComponent } from '@glimmerx/core';
-import { hbs } from '@glimmerx/component';
 renderComponent(_setComponentTemplate(class extends _Component {}, {
   id: "/eBDGAqT",
   block: "{\"symbols\":[\"@name\"],\"statements\":[[7,\"h1\",true],[9],[0,\"Hello \"],[1,[24,1,[]],false],[10]],\"hasEval\":false}",

--- a/packages/@glimmerx/babel-plugin-component-templates/test/index.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/index.js
@@ -15,9 +15,21 @@ pluginTester({
       pluginOptions: astTransformTestPluginOptions,
     },
     {
+      title: 'options.precompile : ast transfrom hbs only',
+      fixture: path.join(__dirname, 'fixtures-options/precompile/ast-transform-hbs/code.js'),
+      outputFixture: path.join(__dirname, 'fixtures-options/precompile/ast-transform-hbs/output.js'),
+      pluginOptions: astTransformTestPluginOptions,
+    },
+    {
       title: 'options.precompile : disabled',
       fixture: path.join(__dirname, 'fixtures-options/precompile/disabled/code.js'),
       outputFixture: path.join(__dirname, 'fixtures-options/precompile/disabled/output.js'),
+      pluginOptions: disabledPrecompilePluginOptions,
+    },
+    {
+      title: 'options.precompile : disabled hbs only',
+      fixture: path.join(__dirname, 'fixtures-options/precompile/disabled-hbs/code.js'),
+      outputFixture: path.join(__dirname, 'fixtures-options/precompile/disabled-hbs/output.js'),
       pluginOptions: disabledPrecompilePluginOptions,
     }
   ],

--- a/packages/example-app/src/MyComponent.ts
+++ b/packages/example-app/src/MyComponent.ts
@@ -16,6 +16,8 @@ const isCJK = helper(function(args, hash, { services }) {
          localeService.currentLocale === 'ja_JP';
 });
 
+const TemplateOnlyComponent = hbs`<h1>I am rendered by a template only component: {{@name}}</h1>`;
+
 class MyComponent extends Component {
   static template = hbs`
     <h1>Hello {{this.message}}</h1> <br/>
@@ -29,6 +31,7 @@ class MyComponent extends Component {
 
     <OtherComponent @count={{this.count}} /> <br/>
     <button {{on "click" this.increment}}>Increment</button>
+    <TemplateOnlyComponent @name="For Glimmerx"/>
   `;
 
   message = 'hello world';


### PR DESCRIPTION
## Background
Today we have a babel plugin in glimmer lite that knows how to convert a class based glimmer component to work with the glimmer lite runtime


### Example
```js
import Component, { hbs } from '@glimmerx/component';

export default class HelloWorldComponent extends Component {
  static template = hbs`<h1>Hello {{this.name}}</h1>`
  
  get name() {
    return 'Abhishek';
  }
}
```

gets transformed to

```js
import { setComponentTemplate as _setComponentTemplate } from '@glimmerx/core';

class HelloWorldComponent extends Component {
  get name() {
    return 'Abhishek';
  }
}

export default _setComponentTemplate(HelloWorldComponent, {/*compiledTemplate in here*/});
```

## Problem Statement
The current solution requires authors to always define a class for their components even if one isn't needed. This makes it more verbose to define a template only component as well as render it.

## Proposed Solution
We should augment the existing babel plugin to able to handle template only components. 

### Example
```js
import { render } from '@glimmerx/core';
import { hbs } from '@glimmerx/component';

render(hbs`<h1>Hello {{@name}}</h1>`, {
  args: {
    name: 'Abhishek'
  },
  element: document.body
})
```

gets transformed to

```js
import { render, setComponentTemplate as _setComponentTemplate } from '@glimmerx/core';
import Component, { hbs } from '@glimmerx/component';

render(_setComponentTemplate(class extends Component {}, {/* compiled template */}), {
  args: {
    name: 'Abhishek'
  },
  element: document.body
})
```

## Testing Done
On Example app `yarn start`

![Glimmer_Demo2](https://user-images.githubusercontent.com/1085393/72576338-47d1ed00-3884-11ea-8ca0-854e34542595.png)


