### PR TITLE
Swapping scope function generator to create new identifiers

### DIFF
--- a/packages/@glimmerx/babel-plugin-component-templates/index.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/index.js
@@ -310,7 +310,7 @@ module.exports = function(babel, options) {
             .map(binding => {
               const { identifier } = binding;
               binding.reference(path);
-              return t.objectProperty(t.identifier(identifier.name), identifier, false, false);
+              return t.objectProperty(t.identifier(identifier.name), t.identifier(identifier.name), false, false);
             })
             .filter(prop => templateScopeTokens.includes(prop.key.name))
         )

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-same-scope-var-commonjs/.babelrc
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-same-scope-var-commonjs/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": true
+        }
+      }
+    ]
+  ]
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-same-scope-var-commonjs/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-same-scope-var-commonjs/code.js
@@ -1,0 +1,11 @@
+import Component, { hbs } from '@glimmerx/component';
+import { OtherComponent as ExternalComponent } from 'somewhere';
+
+class MyComponent extends Component {
+  static template = hbs`<h1>Hello <ExternalComponent/></h1>`
+}
+
+class OtherComponent extends Component {
+  static template = hbs`<h1>Hello <ExternalComponent/></h1>`
+}
+

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-same-scope-var-commonjs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-same-scope-var-commonjs/output.js
@@ -1,0 +1,33 @@
+"use strict";
+
+var _core = require("@glimmerx/core");
+
+var _component = _interopRequireDefault(require("@glimmerx/component"));
+
+var _somewhere = require("somewhere");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+class MyComponent extends _component.default {}
+
+(0, _core.setComponentTemplate)(MyComponent, {
+  id: "XMWw57ep",
+  block: "{\"symbols\":[],\"statements\":[[7,\"h1\",true],[9],[0,\"Hello \"],[5,\"ExternalComponent\",[],[[],[]],null],[10]],\"hasEval\":false}",
+  meta: {
+    scope: () => ({
+      ExternalComponent: _somewhere.OtherComponent
+    })
+  }
+})
+
+class OtherComponent extends _component.default {}
+
+(0, _core.setComponentTemplate)(OtherComponent, {
+  id: "XMWw57ep",
+  block: "{\"symbols\":[],\"statements\":[[7,\"h1\",true],[9],[0,\"Hello \"],[5,\"ExternalComponent\",[],[[],[]],null],[10]],\"hasEval\":false}",
+  meta: {
+    scope: () => ({
+      ExternalComponent: _somewhere.OtherComponent
+    })
+  }
+})


### PR DESCRIPTION
This was originally missing in [PR#41](https://github.com/tomdale/glimmer-lite-donut/pull/41). Check the description of that PR for a summary of the issue.