### PR TITLE
Adding support to pass-in context data to Glimmer Stories/Components

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:watch": "testem",
     "lint": "eslint . --cache --ext .js,.ts",
     "test:node": "mocha -r esm --timeout 5000 packages/@glimmerx/babel-plugin-component-templates/test packages/@glimmerx/eslint-plugin/test/lib/rules",
-    "storybook": "yarn workspace example-app storybook"
+    "storybook": "yarn build && yarn workspace example-app storybook"
   },
   "workspaces": [
     "packages/*",

--- a/packages/@glimmerx/storybook/README.md
+++ b/packages/@glimmerx/storybook/README.md
@@ -59,10 +59,17 @@ Now create a ../stories/index.js file, and write your first story like this:
 
 ```js
 import { storiesOf } from '@glimmerx/storybook';
-import SampleComponent from '../src/SampleComponent';
+import OtherComponent from './OtherComponent';
 import { hbs } from '@glimmerx/component';
 
-storiesOf('Sample', module).add('SampleComponent', () => hbs`<SampleComponent />`);
+storiesOf('Example Stories', module)
+.add('OtherComponent', () => hbs`<OtherComponent @count=101/>`)
+.add('OtherComponent with context data', () => ({
+  componentClass: OtherComponent,
+  componentArgs: {
+    count: 1007
+  }
+}));
 ```
 Each story is a single state of your component. In the above case, there is a story using the SampleComponent.
 

--- a/packages/@glimmerx/storybook/src/client/preview/index.ts
+++ b/packages/@glimmerx/storybook/src/client/preview/index.ts
@@ -4,11 +4,11 @@ import { ClientStoryApi, Loadable } from '@storybook/addons';
 
 import './globals';
 import render from './render';
-import { StoryFnGlimmerReturnType, IStorybookSection } from './types';
+import { GlimmerStoryFnReturnType, IStorybookSection } from './types';
 
 const framework = 'glimmer';
 
-interface ClientApi extends ClientStoryApi<StoryFnGlimmerReturnType> {
+interface ClientApi extends ClientStoryApi<GlimmerStoryFnReturnType> {
   setAddon(addon: any): void;
   configure(loader: Loadable, module: NodeModule): void;
   getStorybook(): IStorybookSection[];

--- a/packages/@glimmerx/storybook/src/client/preview/render.ts
+++ b/packages/@glimmerx/storybook/src/client/preview/render.ts
@@ -1,6 +1,6 @@
 import { document } from 'global';
-import { RenderMainArgs } from './types';
-import { renderComponent } from '@glimmerx/core';
+import { RenderMainArgs, GlimmerStoryFnReturnType, GlimmerStoryComponentClass } from './types';
+import { renderComponent, RenderComponentOptions } from '@glimmerx/core';
 
 const rootElement = document ? document.getElementById('root') : null;
 
@@ -10,8 +10,19 @@ const rootElement = document ? document.getElementById('root') : null;
  * @param {function} showMain - The function to initialize Storybook elements.
  */
 export default function renderMain({ storyFn, showMain }: RenderMainArgs) {
-  const glimmerStoryComponent: any = storyFn();
+  const storyFnResult: GlimmerStoryFnReturnType = storyFn();
+  let glimmerStoryComponent: GlimmerStoryComponentClass;
+  let glimmerRenderComponentOptions: RenderComponentOptions = {
+    element: rootElement,
+  };
+
+  if (typeof storyFnResult === 'function') {
+    glimmerStoryComponent = storyFnResult;
+  } else {
+    glimmerStoryComponent = storyFnResult.componentClass;
+    glimmerRenderComponentOptions.args = storyFnResult.componentArgs;
+  }
   rootElement.innerHTML = '';
   showMain();
-  return renderComponent(glimmerStoryComponent, { element: rootElement });
+  return renderComponent(glimmerStoryComponent, glimmerRenderComponentOptions);
 }

--- a/packages/@glimmerx/storybook/src/client/preview/types.ts
+++ b/packages/@glimmerx/storybook/src/client/preview/types.ts
@@ -1,8 +1,18 @@
-import { StoryFn } from '@storybook/addons';
 import { Constructor } from '@glimmerx/core';
 import GlimmerComponent from '@glimmerx/component';
 
-export type StoryFnGlimmerReturnType = string | Constructor<GlimmerComponent>;
+export type GlimmerStoryFnReturnType =
+  | GlimmerStoryComponentClass
+  | GlimmerStoryComponentClassWithData;
+
+export type GlimmerStoryComponentClass = Constructor<GlimmerComponent>;
+
+export interface GlimmerStoryComponentClassWithData {
+  componentClass: GlimmerStoryComponentClass;
+  componentArgs: {
+    [key: string]: any;
+  };
+}
 
 export interface IStorybookStory {
   name: string;
@@ -20,7 +30,7 @@ export interface ShowErrorArgs {
 }
 
 export interface RenderMainArgs {
-  storyFn: () => StoryFn<StoryFnGlimmerReturnType>;
+  storyFn: () => GlimmerStoryFnReturnType;
   selectedKind: string;
   selectedStory: string;
   showMain: () => void;

--- a/packages/example-app/src/OtherComponent.stories.ts
+++ b/packages/example-app/src/OtherComponent.stories.ts
@@ -2,4 +2,11 @@ import { storiesOf } from '@glimmerx/storybook';
 import OtherComponent from './OtherComponent';
 import { hbs } from '@glimmerx/component';
 
-storiesOf('Example Stories', module).add('OtherComponent', () => hbs`<OtherComponent @count=101/>`);
+storiesOf('Example Stories', module)
+.add('OtherComponent', () => hbs`<OtherComponent @count=101/>`)
+.add('OtherComponent with context data', () => ({
+  componentClass: OtherComponent,
+  componentArgs: {
+    count: 1007
+  }
+}));


### PR DESCRIPTION
## Problem
- Enable rendering of high order glimmer compoents directly as stories & pass in context data to it
- We keep the existing hbs`` support for simple component stories

## Solution:
building support for
```js
import { storiesOf } from '@glimmerx/storybook';
import OtherComponent from './OtherComponent';
import { hbs } from '@glimmerx/component';

storiesOf('Example Stories', module)
.add('OtherComponent', () => hbs`<OtherComponent @count=101/>`)
.add('OtherComponent with context data', () => ({
  componentClass: OtherComponent,
  componentArgs: {
    count: 1007
  }
}));
```

## Testing:
Example app

![storybook_data](https://user-images.githubusercontent.com/1085393/73320624-c586e880-41f4-11ea-9d53-ebe0acbf1ec6.png)
