### PR TITLE
Changes to add `renderOptions` support for stories

### DIFF
--- a/packages/@glimmerx/storybook/README.md
+++ b/packages/@glimmerx/storybook/README.md
@@ -64,10 +64,12 @@ import { hbs } from '@glimmerx/component';
 
 storiesOf('Example Stories', module)
 .add('OtherComponent', () => hbs`<OtherComponent @count=101/>`)
-.add('OtherComponent with context data', () => ({
+.add('OtherComponent with render options', () => ({
   componentClass: OtherComponent,
-  componentArgs: {
-    count: 1007
+  renderOptions: {
+    args: {
+      count: 1007
+    }
   }
 }));
 ```

--- a/packages/@glimmerx/storybook/src/client/preview/render.ts
+++ b/packages/@glimmerx/storybook/src/client/preview/render.ts
@@ -20,7 +20,10 @@ export default function renderMain({ storyFn, showMain }: RenderMainArgs) {
     glimmerStoryComponent = storyFnResult;
   } else {
     glimmerStoryComponent = storyFnResult.componentClass;
-    glimmerRenderComponentOptions.args = storyFnResult.componentArgs;
+    glimmerRenderComponentOptions = {
+      ...glimmerRenderComponentOptions,
+      ...storyFnResult.renderOptions,
+    };
   }
   rootElement.innerHTML = '';
   showMain();

--- a/packages/@glimmerx/storybook/src/client/preview/types.ts
+++ b/packages/@glimmerx/storybook/src/client/preview/types.ts
@@ -1,17 +1,15 @@
-import { Constructor } from '@glimmerx/core';
+import { Constructor, RenderComponentOptions } from '@glimmerx/core';
 import GlimmerComponent from '@glimmerx/component';
 
 export type GlimmerStoryFnReturnType =
   | GlimmerStoryComponentClass
-  | GlimmerStoryComponentClassWithData;
+  | GlimmerStoryWithComponentRenderOptions;
 
 export type GlimmerStoryComponentClass = Constructor<GlimmerComponent>;
 
-export interface GlimmerStoryComponentClassWithData {
+export interface GlimmerStoryWithComponentRenderOptions {
   componentClass: GlimmerStoryComponentClass;
-  componentArgs: {
-    [key: string]: any;
-  };
+  renderOptions: RenderComponentOptions;
 }
 
 export interface IStorybookStory {

--- a/packages/example-app/src/MyComponent.stories.ts
+++ b/packages/example-app/src/MyComponent.stories.ts
@@ -1,0 +1,13 @@
+import { storiesOf } from '@glimmerx/storybook';
+import MyComponent from './MyComponent';
+import LocaleService from './services/LocaleService';
+
+storiesOf('MyComponent Stories', module)
+.add('With service passed in render options', () => ({
+  componentClass: MyComponent,
+  renderOptions: {
+    services: {
+      locale: new LocaleService('fr_FR')
+    }
+  }
+}));

--- a/packages/example-app/src/OtherComponent.stories.ts
+++ b/packages/example-app/src/OtherComponent.stories.ts
@@ -2,11 +2,13 @@ import { storiesOf } from '@glimmerx/storybook';
 import OtherComponent from './OtherComponent';
 import { hbs } from '@glimmerx/component';
 
-storiesOf('Example Stories', module)
-.add('OtherComponent', () => hbs`<OtherComponent @count=101/>`)
-.add('OtherComponent with context data', () => ({
+storiesOf('OtherComponent Stories', module)
+.add('Basic with hbs', () => hbs`<OtherComponent @count=101/>`)
+.add('With render options', () => ({
   componentClass: OtherComponent,
-  componentArgs: {
-    count: 1007
+  renderOptions: {
+    args: {
+      count: 1007
+    }
   }
 }));


### PR DESCRIPTION
What/Why?
- Render options for a glimmer component include more than just arguments e.g. services
more details: https://github.com/tomdale/glimmer-lite-donut/blob/master/packages/%40glimmerx/core/src/renderComponent/index.ts#L21
- We allow passing these render options to a Glimmer story component with this change

Testing Done:
- Passing service to a sample Glimmer Component story in example app
![Storybook](https://user-images.githubusercontent.com/1085393/73963027-5bd99f00-48c4-11ea-98ac-fac2f2f3a043.png)
