### PR TITLE
Add Support for curried components to linter rule

### DIFF
--- a/packages/@glimmerx/babel-plugin-component-templates/index.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/index.js
@@ -48,7 +48,7 @@ function tokensFromType(node, scopedTokens) {
 function addTokens(tokensSet, node, scopedTokens, nativeTokens = []) {
   const maybeTokens = tokensFromType(node, scopedTokens);
   (Array.isArray(maybeTokens) ? maybeTokens : [maybeTokens]).forEach(maybeToken => {
-    if (maybeToken !== undefined && !nativeTokens.includes(maybeToken)) {
+    if (maybeToken !== undefined && !nativeTokens.includes(maybeToken) && !maybeToken.startsWith('@')) {
       tokensSet.add(maybeToken);
     }
   });

--- a/packages/@glimmerx/eslint-plugin/lib/rules/template-vars.js
+++ b/packages/@glimmerx/eslint-plugin/lib/rules/template-vars.js
@@ -36,7 +36,7 @@ module.exports = {
     ],
   },
   create(context) {
-    const defaultNativeTokens = ['if', 'each', 'unless', 'has-block', 'yield'];
+    const defaultNativeTokens = ['if', 'each', 'unless', 'has-block', 'yield', 'component'];
     let isGlimmerSfc = false;
     let hbsImportId;
 

--- a/packages/@glimmerx/eslint-plugin/test/lib/rules/template-vars.js
+++ b/packages/@glimmerx/eslint-plugin/test/lib/rules/template-vars.js
@@ -207,6 +207,34 @@ ruleTester.run('template-vars', rule, {
         import { hbs } from '@glimmerx/component';
         export default class Component {
           static template = hbs\`
+            {{!This is for instances where an argument is a curried component}}
+            <@blockParamDoesNotCauseAFailure/>
+          \`;
+          method() {
+            return false;
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        import { hbs } from '@glimmerx/component';
+        export default class Component {
+          static template = hbs\`
+            {{!This is for instances where an argument is a curried component}}
+            {{component 'SomeComponent'}}
+          \`;
+          method() {
+            return false;
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        import { hbs } from '@glimmerx/component';
+        export default class Component {
+          static template = hbs\`
             {{#if}}
               If check should not cause a failure
             {{/if}}


### PR DESCRIPTION
Currently if a Curried Component is passed in as an arg to a component, and then invoked with angle bracket syntax in that component, the linter will flag the variable as undefined.

Fixed this by checking `.startsWith('@')` before adding a token to the list of tokens (as variables in JS can't start with `@`)

[EDIT] also added `component` to list of native helpers