### PR TITLE
bugfix: Ensure plugin interops with other plugins

### DIFF
--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/class-declaration/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/class-declaration/code.js
@@ -1,0 +1,5 @@
+import Component, { hbs } from '@glimmerx/component';
+
+class MyComponent extends Component {
+  static template = hbs`<h1>{{_t "foo"}}</h1>`;
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/class-declaration/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/class-declaration/output.js
@@ -1,0 +1,16 @@
+import _hbs from "glimmer-inline-precompile";
+import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import { t as _t } from "t-helper";
+import Component from '@glimmerx/component';
+
+class MyComponent extends Component {}
+
+_setComponentTemplate(MyComponent, (() => {
+  const compiledTemplate = _hbs`<h1>{{_t "foo"}}</h1>`;
+
+  compiledTemplate.meta.scope = () => ({
+    _t: _t
+  });
+
+  return compiledTemplate;
+})())

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/class-expression/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/class-expression/code.js
@@ -1,0 +1,5 @@
+import Component, { hbs } from '@glimmerx/component';
+
+const MyComponent = class extends Component {
+  static template = hbs`<h1>{{_t "foo"}}</h1>`;
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/class-expression/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/class-expression/output.js
@@ -1,0 +1,14 @@
+import _hbs from "glimmer-inline-precompile";
+import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import { t as _t } from "t-helper";
+import Component from '@glimmerx/component';
+
+const MyComponent = _setComponentTemplate(class extends Component {}, (() => {
+  const compiledTemplate = _hbs`<h1>{{_t "foo"}}</h1>`;
+
+  compiledTemplate.meta.scope = () => ({
+    _t: _t
+  });
+
+  return compiledTemplate;
+})());

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/template-only-component/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/template-only-component/code.js
@@ -1,0 +1,6 @@
+import { hbs } from '@glimmerx/component';
+import OtherComponent from './OtherComponent';
+import YetAnotherComponent from './YetAnotherComponent';
+
+const template1 = hbs`{{_t "bar"}}<h1>Hello world</h1><OtherComponent/>`;
+const template2 = hbs`{{_t "foo"}}<YetAnotherComponent/>`;

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/template-only-component/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/template-only-component/output.js
@@ -1,0 +1,28 @@
+import _hbs from "glimmer-inline-precompile";
+import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import _Component from "@glimmerx/component";
+import { t as _t } from "t-helper";
+import OtherComponent from './OtherComponent';
+import YetAnotherComponent from './YetAnotherComponent';
+
+const template1 = _setComponentTemplate(class extends _Component {}, (() => {
+  const compiledTemplate = _hbs`{{_t "bar"}}<h1>Hello world</h1><OtherComponent/>`;
+
+  compiledTemplate.meta.scope = () => ({
+    OtherComponent: OtherComponent,
+    _t: _t
+  });
+
+  return compiledTemplate;
+})());
+
+const template2 = _setComponentTemplate(class extends _Component {}, (() => {
+  const compiledTemplate = _hbs`{{_t "foo"}}<YetAnotherComponent/>`;
+
+  compiledTemplate.meta.scope = () => ({
+    YetAnotherComponent: YetAnotherComponent,
+    _t: _t
+  });
+
+  return compiledTemplate;
+})());

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-declaration/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-declaration/code.js
@@ -1,0 +1,5 @@
+import Component, { hbs } from '@glimmerx/component';
+
+class MyComponent extends Component {
+  static template = hbs`<h1>{{_t "foo"}}</h1>`;
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-declaration/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-declaration/output.js
@@ -1,0 +1,15 @@
+import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import { t as _t } from "t-helper";
+import Component from '@glimmerx/component';
+
+class MyComponent extends Component {}
+
+_setComponentTemplate(MyComponent, {
+  id: "8vgn+QAw",
+  block: "{\"symbols\":[],\"statements\":[[7,\"h1\",true],[9],[1,[29,\"_t\",[\"foo\"],null],false],[10]],\"hasEval\":false}",
+  meta: {
+    scope: () => ({
+      _t: _t
+    })
+  }
+})

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-expression/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-expression/code.js
@@ -1,0 +1,5 @@
+import Component, { hbs } from '@glimmerx/component';
+
+const MyComponent = class extends Component {
+  static template = hbs`<h1>{{_t "foo"}}</h1>`;
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-expression/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-expression/output.js
@@ -1,0 +1,13 @@
+import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import { t as _t } from "t-helper";
+import Component from '@glimmerx/component';
+
+const MyComponent = _setComponentTemplate(class extends Component {}, {
+  id: "8vgn+QAw",
+  block: "{\"symbols\":[],\"statements\":[[7,\"h1\",true],[9],[1,[29,\"_t\",[\"foo\"],null],false],[10]],\"hasEval\":false}",
+  meta: {
+    scope: () => ({
+      _t: _t
+    })
+  }
+});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/template-only-component/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/template-only-component/code.js
@@ -1,0 +1,3 @@
+import { hbs } from '@glimmerx/component';
+
+const someTemplate = hbs`<h1>{{_t "foo"}}</h1>`;

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/template-only-component/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/template-only-component/output.js
@@ -1,0 +1,13 @@
+import { setComponentTemplate as _setComponentTemplate } from "@glimmerx/core";
+import _Component from "@glimmerx/component";
+import { t as _t } from "t-helper";
+
+const someTemplate = _setComponentTemplate(class extends _Component {}, {
+  id: "8vgn+QAw",
+  block: "{\"symbols\":[],\"statements\":[[7,\"h1\",true],[9],[1,[29,\"_t\",[\"foo\"],null],false],[10]],\"hasEval\":false}",
+  meta: {
+    scope: () => ({
+      _t: _t
+    })
+  }
+});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/index.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/index.js
@@ -2,6 +2,8 @@ import plugin from '..';
 import pluginTester from 'babel-plugin-tester';
 import path from 'path';
 import astTransformTestPluginOptions from './fixtures-options/precompile/ast-transform/options';
+const { addNamed } = require('@babel/helper-module-imports');
+
 
 // For correct .babelrc detection inside the fixture directory we need to force babel's cwd and root to be the package root.
 // This will ensure that the tests will run correctly from the mono repo root or package root.
@@ -29,3 +31,51 @@ pluginTester({
     },
   ],
 });
+
+pluginTester({
+  plugin: () => { return { name: 'ordering-of-plugins', visitor: {} }},
+  babelOptions: {
+    cwd: packageRootPath,
+    root: packageRootPath,
+    plugins: [
+      [addImport],
+      [plugin],
+      ['@babel/plugin-proposal-class-properties', { loose: true }]
+    ]
+  },
+  fixtures: path.join(__dirname, 'fixtures-compat')
+})
+
+pluginTester({
+  plugin: () => { return { name: 'ordering-of-plugins-precompile-options', visitor: {} }},
+  babelOptions: {
+    cwd: packageRootPath,
+    root: packageRootPath,
+    plugins: [
+      [addImport],
+      [plugin, {
+        "precompile": {
+          "disabled": true
+        }
+      }],
+      ['@babel/plugin-proposal-class-properties', { loose: true }]
+    ]
+  },
+  fixtures: path.join(__dirname, 'fixtures-compat-options')
+})
+
+
+function addImport() {
+  return {
+    name: 'introduce-import',
+    visitor: {
+      Program(path) {
+        addNamed(path, 't', 't-helper');
+        path.get('body').forEach(declaration => {
+          declaration.isImportDeclaration() &&
+            path.scope.registerDeclaration(declaration);
+        });
+      }
+    }
+  }
+}


### PR DESCRIPTION
Prior to this PR the babel plugin would traverse within the entering of
the Program node. The unintended consquence of this was that if plugins
that ran before injected Invokables into module scope, for example a "t"
helper for translations, this plugin would never see those injected
bindings.

The PR, moves all the logic to the main visitor and explicitly handles
the 3 cases:

- Template Only Components
- ClassExpression Components
- ClassDeclaration Components

Prior to this we relying on reenterant behavior which made the code hard
to follow and debug.
