### PR TITLE
[BUGFIX] Fix Babel transform interactions with other transforms

### DIFF
--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/glimmer-env/.babelrc
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/glimmer-env/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "@glimmer/babel-plugin-glimmer-env"
+  ]
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/glimmer-env/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/glimmer-env/code.js
@@ -1,0 +1,14 @@
+import Component, { hbs } from '@glimmerx/component';
+import OtherComponent from './OtherComponent';
+const unknownValue = null;
+const MaybeComponent = null;
+const maybeModifier = null;
+import { DEBUG } from '@glimmer/env';
+
+if (DEBUG) {
+  // do a thing
+}
+
+class MyComponent extends Component {
+  static template = hbs`<h1 {{maybeModifier}}>Hello world {{unknownValue}}<MySubComponent><MaybeComponent /></MySubComponent></h1>`;
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/glimmer-env/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/glimmer-env/output.js
@@ -1,0 +1,25 @@
+import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
+import Component from '@glimmerx/component';
+import OtherComponent from './OtherComponent';
+const unknownValue = null;
+const MaybeComponent = null;
+const maybeModifier = null;
+
+if (true
+/* DEBUG */
+) {// do a thing
+}
+
+class MyComponent extends Component {}
+
+_setComponentTemplate(MyComponent, {
+  id: "hNaOsjkR",
+  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",false],[3,0,0,[27,[26,0,\"ModifierHead\"],[]],null,null],[10],[1,1,0,0,\"Hello world \"],[1,0,0,0,[27,[26,1,\"AppendSingleId\"],[]]],[7,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[7,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[11]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
+  meta: {
+    scope: () => ({
+      unknownValue: unknownValue,
+      MaybeComponent: MaybeComponent,
+      maybeModifier: maybeModifier
+    })
+  }
+})

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/typescript/.babelrc
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/typescript/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "@babel/preset-typescript"
+  ]
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/typescript/code.ts
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/typescript/code.ts
@@ -1,0 +1,13 @@
+import Component, { hbs } from '@glimmerx/component';
+import { Dict } from '@glimmer/interfaces';
+import MaybeComponent from './somewhere-else';
+const unknownValue = null;
+const maybeModifier = null;
+
+export function foo(): Dict<unknown> {
+  return {};
+}
+
+export class MyComponent extends Component {
+  static template = hbs`<h1 {{maybeModifier}}>Hello world {{unknownValue}}<MySubComponent><MaybeComponent /></MySubComponent></h1>`;
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/typescript/output.ts
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/typescript/output.ts
@@ -1,0 +1,21 @@
+import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
+import Component from '@glimmerx/component';
+import MaybeComponent from './somewhere-else';
+const unknownValue = null;
+const maybeModifier = null;
+export function foo() {
+  return {};
+}
+export class MyComponent extends Component {}
+
+_setComponentTemplate(MyComponent, {
+  id: "hNaOsjkR",
+  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",false],[3,0,0,[27,[26,0,\"ModifierHead\"],[]],null,null],[10],[1,1,0,0,\"Hello world \"],[1,0,0,0,[27,[26,1,\"AppendSingleId\"],[]]],[7,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[7,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[11]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
+  meta: {
+    scope: () => ({
+      MaybeComponent: MaybeComponent,
+      unknownValue: unknownValue,
+      maybeModifier: maybeModifier
+    })
+  }
+});


### PR DESCRIPTION
While working on some quality of life improvements in the repo, I found
some buggy interactions between the Babel transform and other
transforms. Specifically, the `@babel/preset-typescript` transform and
the `@glimmer/babel-plugin-glimmer-env` transform.

In the first case, the TypeScript transform removes all imports bindings
that no longer have references once types are removed, and it does this
_before_ our transform has a chance to run. This results in imported
values being removed, even though they are used in templates.

In the case of the `@glimmer/babel-plugin-glimmer-env`, referencing the
Program path directly causes errors when it goes to _replace_ references
to the `DEBUG` binding.

This PR updates the logic to create an empty path that is added to the
AST and referenced properly, so TS doesn't remove values and
`@glimmer/env` can "replace" it correctly. We also avoid adding this
extra reference to any _type_ bindings, because then they _won't_ be
removed.

The alternative would be to skip the queue by using the `Program` to
iterate the AST, but that seems like it would be more brittle than this.